### PR TITLE
Don't try to insert an unreasonable amount of watter into the poor kettle

### DIFF
--- a/src/main/java/plus/dragons/createcentralkitchen/content/logistics/block/mechanicalArm/KettlePoint.java
+++ b/src/main/java/plus/dragons/createcentralkitchen/content/logistics/block/mechanicalArm/KettlePoint.java
@@ -122,7 +122,7 @@ public class KettlePoint extends ArmInteractionPoint {
             remainder.shrink(1);
             container = Items.BUCKET.getDefaultInstance();
         } else if (stack.is(Items.POTION) && PotionUtils.getPotion(stack) == Potions.WATER) {
-            waterIncrement = Math.max(stack.getCount(), 3 - waterLevel);
+            waterIncrement = Math.min(stack.getCount(), 3 - waterLevel);
             remainder.shrink(waterIncrement);
             container = new ItemStack(Items.GLASS_BOTTLE, waterIncrement);
         }


### PR DESCRIPTION
Should fix #41

Cannot test it since I have no experience with the mod(s) invovled, but here is the reasoning:

Water level is 2
I have 5 Bottles

`Math.max(5, 1)`
It now tries to increment by 5 since that is the higher value

`Math.min(5, 1)`
It increments by 1 and that is all we need

---

Water level is 1
I have 1 Bottle

`Math.max(1, 2)`
It now tries to increment by 2 even though I only have 1 Bottle

`Math.min(1, 2)`
It increments by 1 since I only have 1 bottle

---

With `min` it should only increment by a maximum of 3 since that is the highest `3 - waterLevel` can go