### PR TITLE
Autofix: Tomato Sauce tagged as minecraft:water..

### DIFF
--- a/src/main/java/plus/dragons/createcentralkitchen/entry/fluid/FDFluidEntries.java
+++ b/src/main/java/plus/dragons/createcentralkitchen/entry/fluid/FDFluidEntries.java
@@ -42,7 +42,7 @@ public class FDFluidEntries {
             CentralKitchen.genRL("fluid/tomato_sauce_flow"),
             NoTintFluidType::new)
         .lang("Tomato Sauce")
-        .transform(OptionalTags.fluid(FluidTags.WATER))
+        // Removed water tag to prevent interchangeability with water in recipes
         .properties(b -> b
             .sound(SoundActions.BUCKET_EMPTY, SoundEvents.BUCKET_EMPTY).sound(SoundActions.BUCKET_FILL, SoundEvents.BUCKET_FILL)
             .viscosity(2000)


### PR DESCRIPTION
Modified the tomato sauce fluid entry to remove the water tag, which was causing it to be interchangeable with water in recipes. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    