### PR TITLE
Update Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'net.neoforged.moddev' version '2.0.141'
     id "me.modmuss50.mod-publish-plugin" version "0.8.4"
     id "com.diffplug.spotless" version "7.0.2"
+    id 'idea'
 }
 
 tasks.named('wrapper', Wrapper).configure {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id 'net.neoforged.moddev' version '1.0.21'
+    id 'net.neoforged.moddev' version '2.0.141'
     id "me.modmuss50.mod-publish-plugin" version "0.8.4"
     id "com.diffplug.spotless" version "7.0.2"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Hi, I recently tried to use this project as dependency and found that it was using Gradle 8.0 and old version of MDG, and it was causing include problem.
Minecraft 1.21.1 scene seemed to have moved to Gradle 9.x considering it's what they use in MDK.
I figured that using latest version would be better so I decided to upstream this.